### PR TITLE
Fixed station mappings GUI errors + added remote function "stationNameFromNumber"

### DIFF
--- a/Train.lua
+++ b/Train.lua
@@ -449,8 +449,13 @@ Train = {
         end
 
         if destination then
-          --log(game.tick .. " Train: "..self.name .. " setting destination signal: " .. self.train.schedule.current)
-          parameters[i]={signal={type = "virtual", name = "signal-destination"}, count = self.train.schedule.current, index = i}
+          local destNumber
+
+          if self.line and global.trainLines[self.line] and global.trainLines[self.line].settings.useMapping then
+            destNumber = global.stationNumbers[cargoProxy.force.name][tostring(self.train.schedule.records[self.train.schedule.current].station)] or false
+          end
+--          log(game.tick .. " Train: "..self.name .. " setting destination signal: " .. (destNumber or self.train.schedule.current))
+          parameters[i]={signal={type = "virtual", name = "signal-destination"}, count = destNumber or self.train.schedule.current, index = i}
           i = i + 1
         end
 

--- a/control.lua
+++ b/control.lua
@@ -1896,5 +1896,14 @@ remote.add_interface("st",
       --      end
       --      game.write_file("st/timing.csv", line, true)
     end,
+    stationNameFromNumber = function(player, stationID)
+      if global.stationMap[player.force.name][stationID] then
+        for name, set in pairs(global.stationMap[player.force.name][stationID]) do
+          if set then return name end
+        end
+      end
+      return ""
+    end,
+
   }
 )

--- a/gui.lua
+++ b/gui.lua
@@ -199,6 +199,7 @@ GUI = {
     --log(serpent.line(trainInfo))
     --log(serpent.line({kUI=keyUI, trainkey=trainKey, t=t}))
     local trainLine = t.line and global.trainLines[t.line] or false
+    local useMapping = trainLine and trainLine.settings.useMapping or false
     gui = GUI.add(gui, {type="frame", name="trainSettings", caption={"", {"lbl-train"}, ": ", t.name, " (", t:getType(),")"}, direction="vertical", style="st_frame"})
     local line = "-"
     local dated = " "
@@ -273,8 +274,15 @@ GUI = {
             end
           end
 
-          if rule.jumpTo and rule.jumpTo <= #records then
+          if rule.jumpTo and not useMapping and rule.jumpTo <= #records then
             table.insert(chunks, {{"lbl-jump-to"}, "", rule.jumpTo})
+          elseif rule.jumpTo and useMapping and global.stationMap[game.players[player_index].force.name][rule.jumpTo] then
+            local mappedID = t:get_first_matching_station(rule.jumpTo, i)
+            if mappedID and mappedID>0 then
+              table.insert(chunks, {{"lbl-jump-to"}, "", mappedID , " (mapped #", rule.jumpTo, ')'})
+            else
+              table.insert(chunks, {"invalid #", " (mapped #", rule.jumpTo, ')'}) --TODO: localisation
+            end
           elseif rule.jumpTo then
             table.insert(chunks, {"invalid #"}) --TODO: localisation
           end


### PR DESCRIPTION
I have fixed "invalid station #" text in the line GUI when using fixed station mapping and the destination signal will get right destination station number when a line uses fixed mapping.

I have added remote function "stationNameFromNumber", which I use in LuaCombinator for obtaining station name instead of station number in my smart train network. I think it might be useful for others.